### PR TITLE
Exclude `/releases` from download url for most recent stable

### DIFF
--- a/src/util/RedisBinaryDownloadUrl.ts
+++ b/src/util/RedisBinaryDownloadUrl.ts
@@ -1,5 +1,6 @@
 import resolveConfig from './resolve-config';
 import debug from 'debug';
+import { LATEST_VERSION } from './RedisBinary';
 
 const log = debug('RedisMS:RedisBinaryDownloadUrl');
 
@@ -38,7 +39,9 @@ export default class RedisBinaryDownloadUrl {
     const mirror = resolveConfig('DOWNLOAD_MIRROR') ?? 'https://download.redis.io';
     log(`Using "${mirror}" as the mirror`);
 
-    return `${mirror}/releases/${archive}`;
+    return this.version === LATEST_VERSION
+      ? `${mirror}/${archive}`
+      : `${mirror}/releases/${archive}`;
   }
 
   /**

--- a/src/util/__tests__/RedisBinaryDownloadUrl-test.ts
+++ b/src/util/__tests__/RedisBinaryDownloadUrl-test.ts
@@ -21,9 +21,7 @@ describe('RedisBinaryDownloadUrl', () => {
         const du = new RedisBinaryDownloadUrl({
           version: 'stable',
         });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://download.redis.io/releases/redis-stable.tar.gz'
-        );
+        expect(await du.getDownloadUrl()).toBe('https://download.redis.io/redis-stable.tar.gz');
       });
 
       it('6.0.10', async () => {


### PR DESCRIPTION
Resolves https://github.com/mhassan1/redis-memory-server/issues/3.

The binary at https://download.redis.io/releases/redis-stable.tar.gz is older than https://download.redis.io/redis-stable.tar.gz. The main [download page](https://download.redis.io/) recommends the second one. This PR changes the behavior to use the second one for the `stable` version.