### PR TITLE
feat: add `instance.killTimeout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ const redisServer = new RedisMemoryServer({
     port: number, // by default, choose any free port
     ip: string, // by default, '127.0.0.1'; for binding to all IP addresses set it to `::,0.0.0.0`,
     args: [], // by default, no additional arguments; any additional command line arguments for `redis-server`
+    killTimeout: number, // by default, 10_000 (milliseconds) for SIGINT or SIGKILL to succeed; some environments may require more time for shutdown
   },
   binary: {
     version: string, // by default, 'stable'

--- a/src/RedisMemoryServer.ts
+++ b/src/RedisMemoryServer.ts
@@ -137,6 +137,7 @@ export default class RedisMemoryServer {
         ip: data.ip,
         port: data.port,
         args: instOpts.args,
+        killTimeout: instOpts.killTimeout,
       },
       binary: this.opts.binary,
       spawn: this.opts.spawn,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export { SpawnOptions } from 'child_process';
 export interface RedisMemoryInstancePropBaseT {
   args?: string[];
   port?: number | null;
+  killTimeout?: number;
 }
 
 export interface RedisMemoryInstancePropT extends RedisMemoryInstancePropBaseT {

--- a/src/util/RedisInstance.ts
+++ b/src/util/RedisInstance.ts
@@ -20,6 +20,7 @@ export interface RedisServerOps {
     port?: number;
     ip?: string; // for binding to all IP addresses set it to `::,0.0.0.0`, by default '127.0.0.1'
     args?: string[];
+    killTimeout?: number;
   };
 
   // redis binary options
@@ -124,6 +125,8 @@ export default class RedisInstance {
   async kill(): Promise<RedisInstance> {
     this.debug('Called RedisInstance.kill():');
 
+    const timeoutTime = this.opts.instance.killTimeout ?? 1000 * 10;
+
     /**
      * Function to De-Duplicate Code
      * @param _process The Process to kill
@@ -136,13 +139,12 @@ export default class RedisInstance {
         return;
       }
 
-      const timeoutTime = 1000 * 10;
       await new Promise((resolve, reject) => {
         let timeout = setTimeout(() => {
           debugfn('kill_internal timeout triggered, trying SIGKILL');
           if (!debug.enabled('RedisMS:RedisInstance')) {
             console.warn(
-              'An Process didnt exit with signal "SIGINT" within 10 seconds, using "SIGKILL"!\n' +
+              `An Process didnt exit with signal "SIGINT" within ${timeoutTime} milliseconds, using "SIGKILL"!\n` +
                 'Enable debug logs for more information'
             );
           }


### PR DESCRIPTION
This PR adds a new `killTimeout` option to `opts.instance`; when set, override the default timeout (10,000 milliseconds) for the `SIGINT` and `SIGKILL` commands in `instance.kill()`.