### PR TITLE
fix: resolving a typo in a debug message

### DIFF
--- a/src/RedisMemoryServer.ts
+++ b/src/RedisMemoryServer.ts
@@ -100,7 +100,7 @@ export default class RedisMemoryServer {
       })
       .catch((err) => {
         if (!debug.enabled('RedisMS:RedisMemoryServer')) {
-          console.warn('Starting the instance failed, please enable debug for more infomation');
+          console.warn('Starting the instance failed, please enable debug for more information.');
         }
         throw err;
       });


### PR DESCRIPTION
This resolves a typo of `infomation` within a debug message that's run when starting the server fails.