### PR TITLE
feat: switch to memurai on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,8 @@ On install, this package auto-downloads and compiles version `stable` of the `re
 
 ### Windows
 
-Although Windows is not officially supported by Redis, but there is a downloadable version of [redis: 3.0.503 (June 28, 2016) for win64 by microsoft](https://github.com/ServiceStack/redis-windows#option-3-running-microsofts-native-port-of-redis). This is an older version. It will work for most of the simple tasks like basic storage and pubsub. Probably what is missing or old is lua scripting.
-
-Please note it will download the redis binary from github from URL: `https://raw.githubusercontent.com/ServiceStack/redis-windows/master/downloads/redis-latest.zip`.
-
-Optionally, you could provide your own URL before running `npm install`:
-`npx cross-env REDISMS_DOWNLOAD_URL='https://raw.githubusercontent.com/ServiceStack/redis-windows/master/downloads/redis-latest.zip' npm install`
+This library uses the latest version of [Memurai](https://www.memurai.com/) on Windows.
+Currently, it is not possible to specify a particular version of Memurai or Redis on Windows.
 
 ### Configuring which `redis-server` binary to use
 

--- a/src/util/__tests__/RedisBinaryDownloadUrl-test.ts
+++ b/src/util/__tests__/RedisBinaryDownloadUrl-test.ts
@@ -53,8 +53,8 @@ describe('RedisBinaryDownloadUrl', () => {
         const du = new RedisBinaryDownloadUrl({
           version: 'stable',
         });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://raw.githubusercontent.com/ServiceStack/redis-windows/master/downloads/redis-latest.zip' // its version 3.0.503, no other version available, hopefully good enough for testing
+        expect(await du.getDownloadUrl()).toMatch(
+          /^https:\/\/download\.memurai\.com\/Memurai-Developer\//
         );
       });
 
@@ -62,8 +62,8 @@ describe('RedisBinaryDownloadUrl', () => {
         const du = new RedisBinaryDownloadUrl({
           version: '6.0.10',
         });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://raw.githubusercontent.com/ServiceStack/redis-windows/master/downloads/redis-latest.zip' // its version 3.0.503, no other version available, hopefully good enough for testing
+        expect(await du.getDownloadUrl()).toMatch(
+          /^https:\/\/download\.memurai\.com\/Memurai-Developer\//
         );
       });
     });


### PR DESCRIPTION
This PR switches the Windows binary from [ServiceStack/redis-windows](https://github.com/ServiceStack/redis-windows) (deprecated) to [Memurai](https://www.memurai.com/).